### PR TITLE
[BUGFIX] Fix wrong type annotation in tests

### DIFF
--- a/tests/Unit/Command/ApplyCommandTest.php
+++ b/tests/Unit/Command/ApplyCommandTest.php
@@ -25,7 +25,7 @@ final class ApplyCommandTest extends CommandTestCase
     }
 
     /**
-     * @param  array<int, string>                       $changeIds
+     * @param  array<int, string>|null                  $changeIds
      * @param  array<string, string|string[]|bool|null> $input
      * @return array<string, string|string[]|bool|null>
      */

--- a/tests/Unit/Command/RemoveCommandTest.php
+++ b/tests/Unit/Command/RemoveCommandTest.php
@@ -25,7 +25,7 @@ final class RemoveCommandTest extends CommandTestCase
     }
 
     /**
-     * @param  array<int, string>                       $changeIds
+     * @param  array<int, string>|null                  $changeIds
      * @param  array<string, string|string[]|bool|null> $input
      * @return array<string, string|string[]|bool|null>
      */

--- a/tests/Unit/Command/UpdateCommandTest.php
+++ b/tests/Unit/Command/UpdateCommandTest.php
@@ -25,7 +25,7 @@ final class UpdateCommandTest extends CommandTestCase
     }
 
     /**
-     * @param  array<int, string>                       $changeIds
+     * @param  array<int, string>|null                  $changeIds
      * @param  array<string, string|string[]|bool|null> $input
      * @return array<string, string|string[]|bool|null>
      */

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -8,6 +8,9 @@
 		"phpstan/phpstan-symfony": "*",
 		"rector/rector": "*"
 	},
+	"conflict": {
+		"phpstan/phpstan-strict-rules": "1.2.0"
+	},
 	"config": {
 		"allow-plugins": {
 			"phpstan/extension-installer": true


### PR DESCRIPTION
In addition a conflict is added for phpstan/phpstan-strict-rules 1.2.0
which does not longer work as expected see
https://github.com/phpstan/phpstan-strict-rules/issues/172