### PR TITLE
[BUGFIX] Perform version comparison with branch name prefix only

### DIFF
--- a/src/Utility/ComposerUtils.php
+++ b/src/Utility/ComposerUtils.php
@@ -561,7 +561,7 @@ final class ComposerUtils
                 }
 
                 foreach ($includedInInfo->branches as $branch) {
-                    if (Semver::satisfies($package->getVersion(), $branch)) {
+                    if (Semver::satisfies($package->getVersion(), 'dev-' . $branch)) {
                         if ($this->askRemoval($appliedChange->getNumber())) {
                             $obsoleteChanges[] = (string)$appliedChange->getNumber();
                             $this->patchUtils->prepareRemove([$appliedChange->getNumber()], $patches);

--- a/tests/Unit/Fixtures/composer.patches.json
+++ b/tests/Unit/Fixtures/composer.patches.json
@@ -1,0 +1,55 @@
+{
+	"name": "gilbertsoft/typo3-core-patches-project",
+	"description": "Project to test the gilbertsoft/typo3-core-patches package.",
+	"license": "MIT",
+	"type": "project",
+	"authors": [
+		{
+			"name": "Simon Gilli",
+			"email": "simon.gilli@gilbertsoft.org",
+			"homepage": "https://gilbertsoft.org",
+			"role": "developer"
+		}
+	],
+	"homepage": "https://github.com/GsTYPO3/core-patches",
+	"require": {
+		"php": "^7.4 || ^8.0",
+		"gilbertsoft/typo3-core-patches": "0.1-dev",
+		"typo3/cms-core": "10.4.22 || 11.5.4",
+		"typo3/minimal": "^10.4 || ^11.5"
+	},
+	"require-dev": {
+		"composer/composer": "^2.0.9",
+		"ergebnis/composer-normalize": "*"
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../..",
+			"options": {
+				"versions": {
+					"gilbertsoft/typo3-core-patches": "0.1-dev"
+				}
+			}
+		}
+	],
+	"config": {
+		"allow-plugins": {
+			"ergebnis/composer-normalize": true,
+			"gilbertsoft/typo3-core-patches": true,
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true
+		},
+		"discard-changes": true
+	},
+	"extra": {
+		"gilbertsoft/typo3-core-patches": {
+			"applied-changes": [73022]
+		},
+		"patches": {
+			"typo3/cms-core": {
+				"Avoid service listing in ext:reports": "patches/typo3-cms-core-review-73022.patch"
+			}
+		}
+	}
+}

--- a/tests/Unit/Utility/ComposerUtilsTest.php
+++ b/tests/Unit/Utility/ComposerUtilsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 Core Patches.
+ *
+ * (c) Gilbertsoft LLC (gilbertsoft.org)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GsTYPO3\CorePatches\Tests\Unit\Utility;
+
+use Composer\Composer;
+use Composer\Factory;
+use Composer\IO\BufferIO;
+use Composer\Package\PackageInterface;
+use GsTYPO3\CorePatches\Tests\Unit\TestCase;
+use GsTYPO3\CorePatches\Utility\ComposerUtils;
+use RuntimeException;
+
+/**
+ * @author Elias Häußler <elias@haeussler.dev>
+ */
+final class ComposerUtilsTest extends TestCase
+{
+    private string $previousWorkingDir;
+
+    private string $testWorkingDir;
+
+    private BufferIO $io;
+
+    private Composer $composer;
+
+    private ComposerUtils $composerUtils;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (($previousWorkingDir = getcwd()) === false) {
+            throw new RuntimeException('Unable to determine current directory.', 1_668_787_261);
+        }
+
+        $this->previousWorkingDir = $previousWorkingDir;
+        $this->testWorkingDir = self::getTestPath();
+        chdir($this->testWorkingDir);
+
+        self::createFiles($this->testWorkingDir, [
+            'composer.json' => 'FIX:composer.patches.json',
+        ]);
+
+        $this->io = new BufferIO();
+        $this->composer = Factory::create($this->io);
+        $this->composerUtils = new ComposerUtils($this->composer, $this->io);
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->previousWorkingDir);
+
+        parent::tearDown();
+    }
+
+    public function testVerifyPatchesForPackageCanHandleBranches(): void
+    {
+        $package = $this->composer->getRepositoryManager()->findPackage('typo3/cms-core', '^11.5');
+
+        self::assertInstanceOf(PackageInterface::class, $package);
+        self::assertSame([], $this->composerUtils->verifyPatchesForPackage($package));
+    }
+}


### PR DESCRIPTION
Composer expects a `dev-` prefix for version requirements referencing branches instead of versions. Therefore, this prefix is now added to the `Semver::satisfies()` call for branch comparison in `ComposerUtils::verifyPatchesForPackage()`. Additionally, a test case is added that covers this potential failure.

Prior to this patch, the following exception may happen when applying a patch:

```
Checking for obsolete patches, this may take a while...

In VersionParser.php line 521:
                                                                          
  [UnexpectedValueException]                                              
  Could not parse version constraint main: Invalid version string "main"  
```